### PR TITLE
fix: Install package to define `python` as `python3`

### DIFF
--- a/src/rosbag-uploader/Dockerfile
+++ b/src/rosbag-uploader/Dockerfile
@@ -1,9 +1,11 @@
 # This Dockerfile builds the rosbag uploader
 
 FROM debian:12-slim AS builder
-# Install `pipx`
+# Install `pipx` and `python-is-python3`, the latter is needed due to `poetry bundle` failing later otherwise, see #4 on GitHub
 RUN apt-get update && \
-    apt-get install --no-install-suggests --no-install-recommends --yes pipx
+    apt-get install --no-install-suggests --no-install-recommends --yes \
+    pipx \
+    python-is-python3
 
 # Refresh path
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
Install package to define `python` as `python3` to address `poetry bundle` failing.

Fixes the following error message:

```
STEP 8/8: RUN poetry bundle venv --python=/usr/bin/python3 --only=main,production /venv

  • Bundling rosbag-uploader (0.1.0) into /venv
  • Bundling rosbag-uploader (0.1.0) into /venv: Creating a virtual environment using Python /usr/bin/python3

[Errno 2] No such file or directory: 'python'
Error: building at STEP "RUN poetry bundle venv --python=/usr/bin/python3 --only=main,production /venv": while running runtime: exit status 1
```