### PR TITLE
fix: Add missing columns during database setup

### DIFF
--- a/src/database/dacs.sql
+++ b/src/database/dacs.sql
@@ -259,6 +259,8 @@ CREATE TABLE IF NOT EXISTS `sensors_meta` (
   `location` varchar(255) DEFAULT NULL COMMENT 'location',
   `ain` varchar(255) DEFAULT NULL COMMENT 'AIN channel',
   `unit` varchar(255) DEFAULT NULL COMMENT 'unit of measurement',
+  `unc` float DEFAULT NULL COMMENT '',
+  `unc_type` varchar(255) DEFAULT NULL COMMENT '',
   PRIMARY KEY (`id`),
   KEY `sensor_id` (`sensor_id`),
   CONSTRAINT `sensors_meta_ibfk_1` FOREIGN KEY (`sensor_id`) REFERENCES `sensors` (`id`)


### PR DESCRIPTION
Add missing columns during database setup. These columns appear to have been added at some point during PROMETHEUS or HELIOS project cycle as they are required by the database ingestion script but are not present in the SQL script for the initial setup.