### PR TITLE
fix: Set max upload size in waitress

### DIFF
--- a/src/rosbag-uploader/rosbag_uploader/main.py
+++ b/src/rosbag-uploader/rosbag_uploader/main.py
@@ -166,6 +166,7 @@ if __name__ == "__main__":
             app,
             host="0.0.0.0",
             port=8000,
+            max_request_body_size=50 * 1024 * 1024 * 1024,
         )
 
     # Fall back to debug server in dev


### PR DESCRIPTION
Set max upload size in waitress to global value of 50GB. Otherwise uploads above 1GB are blocked and will result in an error.
This means uploads of larger collections of rosbags would get blocked.