### PR TITLE
fix: Use correct database hostname

### DIFF
--- a/src/rosbag-uploader/rosbag_uploader/db_utility.py
+++ b/src/rosbag-uploader/rosbag_uploader/db_utility.py
@@ -26,7 +26,7 @@ class DatabaseInstance:
     # Connects to the running MySQL instance, selects the 'dacs' DB and returns a cursor to it
     def establishConnection(self):
         dbConnection = con.connect(
-            host="aris-helios.vsos.ethz.ch",
+            host="database",
             user="root",
             password="Replace_me_wh3n_deploying_on_public_server",
             database="aris",


### PR DESCRIPTION
The hostname defined in the compose file is `database` not the external hostname, i.e. `aris-helios.vsos.ethz.ch`.